### PR TITLE
Refactor CeTZ example in template

### DIFF
--- a/template/main.typ
+++ b/template/main.typ
@@ -39,51 +39,41 @@
   cetz-canvas({
     import cetz.draw: *
 
-    let mark = (end: "triangle", length: 0.2)
-    let textfill = rgb("#333333")
+    let darkgray = luma(20%)
 
     let objects = (
-      (type: "circle", x: 0, y: 0, fill: rgb("000000"), text: "0", textfill: rgb("ffffff")),
-      (type: "circle", x: -3, y: -3, fill: none, text: "1", textfill: textfill),
-      (type: "circle", x: 4, y: -3, fill: none, text: "1", textfill: textfill),
-      (type: "circle", x: 1, y: -5, fill: none, text: "2", textfill: textfill),
-      (type: "circle", x: 5, y: -8, fill: none, text: "2", textfill: textfill),
-      (type: "circle", x: -4.5, y: -7.5, fill: none, text: "2", textfill: textfill),
-      (type: "circle", x: 1.5, y: -9, fill: none, text: "3", textfill: textfill),
-      (type: "circle", x: 8, y: -11,  fill: none, text: "3", textfill: textfill),
+      (pos: (0, 0), name: "n0", fill: black, text: "0", textfill: white),
+      (pos: (-3, -3), name: "n1", fill: none, text: "1", textfill: darkgray),
+      (pos: (4, -3), name: "n2", fill: none, text: "1", textfill: darkgray),
+      (pos: (1, -5), name: "n3", fill: none, text: "2", textfill: darkgray),
+      (pos: (5, -8), name: "n4", fill: none, text: "2", textfill: darkgray),
+      (pos: (-4.5, -7.5), name: "n5", fill: none, text: "2", textfill: darkgray),
+      (pos: (1.5, -9), name: "n6", fill: none, text: "3", textfill: darkgray),
+      (pos: (8, -11),  name: "n7", fill: none, text: "3", textfill: darkgray),
     )
 
     for obj in objects {
-      circle((obj.x,obj.y), radius: (.75, .75), fill: obj.fill)
+      circle(obj.pos, radius: (.75, .75), fill: obj.fill, name: obj.name)
         content(
-          (obj.x, obj.y), 
-          box(
-            width: 2em,
-            height: 1em,
-            align(center + horizon)[
-              #par(
-                leading: 0.4em,
-                text(
-                  size: 14pt,
-                  weight: "medium",
-                  fill: obj.textfill,
-                )[#obj.text]
-              )
-            ]
-          ),
-          anchor: "center"
+          obj.pos, 
+          text(size: 14pt, fill: obj.textfill)[#obj.text]
         )
     }
 
-    line((4, -2.25),(0.75, 0), stroke: (paint: black, thickness: 3pt), mark: mark)
-    line((-3, -2.25),(-0.75, 0), stroke: (paint: black, thickness: 3pt), mark: mark)
-    line((0.25, -5),(-2.25, -3), stroke: (paint: black, thickness: 3pt), mark: mark)
-    line((1.75, -5),(3.25, -3), stroke: (paint: black, thickness: 3pt), mark: mark)
-    line((-4.5, -6.75),(-3, -3.75), stroke: (paint: black, thickness: 3pt), mark: mark)
-    line((1.5, -8.25),(1, -5.75), stroke: (paint: black, thickness: 3pt), mark: mark)
-    line((2.25, -9),(4.25, -8), stroke: (paint: black, thickness: 3pt), mark: mark)
-    line((5, -7.25),(4, -3.75), stroke: (paint: black, thickness: 3pt), mark: mark)
-    line((8, -10.25),(5.75, -8), stroke: (paint: black, thickness: 3pt), mark: mark)
+    let dag_edge = line.with(
+      stroke: (paint: black, thickness: 3pt),
+      mark: (end: "triangle", length: 0.2),
+    )
+
+    dag_edge("n2", "n0")
+    dag_edge("n1", "n0")
+    dag_edge("n3", "n1")
+    dag_edge("n3", "n2")
+    dag_edge("n5", "n1")
+    dag_edge("n6", "n3")
+    dag_edge("n6", "n4")
+    dag_edge("n4", "n2")
+    dag_edge("n7", "n4")
   }),
   caption: [Fully built RPL-DODAG #cite(<dodag-figure>)]
 )


### PR DESCRIPTION
As a newbie to typst and CeTZ, I found the example code surprisingly complex and also noticed that the edges did not move when I changed the node coordinates, so they became detached.  I took this as an example to learn about CeTZ and refactored the code to be simpler and hopefully more readable.